### PR TITLE
Persists the token on redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem 'yajl-ruby'
 
 group :test do
   gem 'fakeweb'
+  gem 'minitest'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     fakeweb (1.3.0)
+    minitest (2.6.0)
     yajl-ruby (0.8.2)
 
 PLATFORMS
@@ -9,4 +10,5 @@ PLATFORMS
 
 DEPENDENCIES
   fakeweb
+  minitest
   yajl-ruby

--- a/lib/ticket_sharing/client.rb
+++ b/lib/ticket_sharing/client.rb
@@ -49,7 +49,7 @@ module TicketSharing
         when Net::HTTPSuccess
           @success = true
           response
-        when Net::HTTPMovedPermanently, Net::HTTPFound
+        when Net::HTTPMovedPermanently, Net::HTTPFound, Net::HTTPRedirection
           request.follow_redirect!
           handle_response(request)
         when Net::HTTPNotFound, Net::HTTPGone, Net::HTTPServerError

--- a/lib/ticket_sharing/request.rb
+++ b/lib/ticket_sharing/request.rb
@@ -1,7 +1,7 @@
 module TicketSharing
   class Request
 
-    attr_reader :raw_response
+    attr_reader :raw_response, :raw_request
 
     MAX_REDIRECTS = 1
 
@@ -32,10 +32,10 @@ module TicketSharing
       if @redirects >= MAX_REDIRECTS
         raise TicketSharing::TooManyRedirects
       end
-
+      token = @raw_request['X-Ticket-Sharing-Token']
       @uri = URI.parse(@raw_response['Location'])
       @raw_request = new_raw_request
-
+      @raw_request['X-Ticket-Sharing-Token'] = token if token
       self.send!
 
       @redirects += 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'minitest/autorun'
 require 'fakeweb'
 


### PR DESCRIPTION
This should fix the 401 errors we've been getting. This adds the token to the header so that the new request contains it on a redirect. 
