### PR TITLE
Setting the `ca_path` on https requests.

### DIFF
--- a/lib/ticket_sharing/request.rb
+++ b/lib/ticket_sharing/request.rb
@@ -6,6 +6,8 @@ module TicketSharing
     # this should very rarely have to go above 2, and definitely never any higher than 5
     MAX_REDIRECTS = 2
 
+    CA_PATH = "/etc/ssl/certs"
+
     def initialize(request_class, uri, body)
       @redirects = 0
       @uri = URI.parse(uri)
@@ -25,7 +27,7 @@ module TicketSharing
 
       if @uri.scheme == 'https'
         http.use_ssl = true
-        http.ca_path = "/etc/ssl/certs" if File.exist?("/etc/ssl/certs")
+        http.ca_path = CA_PATH if File.exist?(CA_PATH)
       end
 
       @raw_response = http.start do |http|


### PR DESCRIPTION
On Ubuntu ssl certificates are stored under `/etc/ssl/certs`.
If that directory exists, look there for certificates.

@pinkvelociraptor @pdeuter 
