### PR TITLE
Asking the parent class for its field list if ours is not present.

### DIFF
--- a/lib/ticket_sharing/base.rb
+++ b/lib/ticket_sharing/base.rb
@@ -12,8 +12,16 @@ module TicketSharing
       @fields || []
     end
 
+    def self.first_ancestor
+      ancestors.detect { |a| a != self }
+    end
+
     def field_list
-      self.class.field_list
+      if self.class.field_list.any?
+        self.class.field_list
+      else
+        self.class.first_ancestor.field_list
+      end
     end
 
     def initialize(attrs = {})

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+require 'ticket_sharing/base'
+
+class BaseTest < MiniTest::Unit::TestCase
+
+  def test_field_list_from_ancestors
+    klass1 = Class.new(TicketSharing::Base) do
+      fields :foo, :bar
+    end
+
+    klass2 = Class.new(klass1)
+
+    assert_equal([:foo, :bar], klass1.new.field_list)
+    assert_equal([:foo, :bar], klass2.new.field_list)
+  end
+
+end


### PR DESCRIPTION
Previously, if you inherited from a ticket sharing base class you did not inherit your parent's field list. Now, we check our fields list, and if it is empty, we use the parent's field list.

This propagation will continue all the way up to the `TicketSharing::Base` class.

cc: @zendesk-jcheatham 
