### PR TITLE
add display_filename to the list of attachments fields shared

### DIFF
--- a/lib/ticket_sharing/attachment.rb
+++ b/lib/ticket_sharing/attachment.rb
@@ -3,7 +3,7 @@ require 'ticket_sharing/base'
 module TicketSharing
   class Attachment < Base
 
-    fields :url, :filename, :content_type
+    fields :url, :filename, :content_type, :display_filename
 
   end
 end

--- a/test/unit/attachment_test.rb
+++ b/test/unit/attachment_test.rb
@@ -7,12 +7,14 @@ class TicketSharing::AttachmentTest < MiniTest::Unit::TestCase
     attributes = {
       'url' => 'http://example.com/',
       'filename' => 'foo.jpg',
+      'display_filename' => 'foo.jpg',
       'content_type' => 'text/jpeg'
     }
     attachment = TicketSharing::Attachment.new(attributes)
 
     assert_equal('http://example.com/', attachment.url)
     assert_equal('foo.jpg', attachment.filename)
+    assert_equal('foo.jpg', attachment.display_filename)
     assert_equal('text/jpeg', attachment.content_type)
   end
 


### PR DESCRIPTION
This avoid the mingling of the filename for non ascii characters on the shared ticket.

\cc @jish 
