### PR TITLE
ZD#1321432 - adds a remove_partner method

### DIFF
--- a/lib/ticket_sharing/agreement.rb
+++ b/lib/ticket_sharing/agreement.rb
@@ -33,6 +33,13 @@ module TicketSharing
       @response.code.to_i
     end
 
+    def remove_partner(url)
+      client = Client.new(url, authentication_token)
+      @response = client.delete(relative_url)
+
+      @response.code.to_i
+    end
+
     def relative_url
       '/agreements/' + uuid.to_s
     end

--- a/test/unit/agreement_test.rb
+++ b/test/unit/agreement_test.rb
@@ -129,6 +129,25 @@ class TicketSharing::AgreementTest < MiniTest::Unit::TestCase
     assert_equal('5ad614f4:APIKEY123', request['X-Ticket-Sharing-Token'])
   end
 
+  def test_should_destroy_partner
+    FakeWeb.last_request = nil
+    FakeWeb.register_uri(:delete,
+      'http://example.com/sharing/agreements/5ad614f4', :body => '')
+
+    attributes = {
+      'receiver_url' => 'http://example.com/sharing',
+      'uuid' => '5ad614f4',
+      'access_key' => 'APIKEY123'
+    }
+
+    agreement = TicketSharing::Agreement.new(attributes)
+    assert agreement.remove_partner(attributes['receiver_url'])
+
+    request = FakeWeb.last_request
+    assert_equal('/sharing/agreements/5ad614f4', request.path)
+    assert_equal('5ad614f4:APIKEY123', request['X-Ticket-Sharing-Token'])
+  end
+
   def test_should_deserialize_current_actor
     json = TicketSharing::JsonSupport.encode({
       'current_actor' => {


### PR DESCRIPTION
When deleting sharing agreements, we currently execute one unshare job per ticket to remove the ticket from the sharing partner.
Instead, we're going to run just one job to delete the agreement on the partner, which will then trigger the soft deletion of all shared tickets in the partner's agreement.
The addition of `remove_partner` is what will allow us to hit the [agreement controller](https://github.com/zendesk/zendesk/blob/master/app/controllers/sharing_agreements_controller.rb#L73-L80) on the partner.

@jcheatham 
/cc @zendesk/sustaining 

### References
* https://support.zendesk.com/agent/tickets/1321432

### Risks
* None