### PR TITLE
Replace FakeWeb with WebMock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rake'
 gem 'bump'
 
 group :test do
-  gem 'fakeweb'
+  gem 'webmock'
   gem 'minitest', '~> 4.0'
   gem 'mocha', '~> 0.13'
   gem 'minitest-rg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     bump (0.4.2)
-    fakeweb (1.3.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    hashdiff (0.2.3)
     metaclass (0.0.1)
     minitest (4.7.4)
     minitest-rg (1.1.0)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     rake (0.9.2.2)
+    safe_yaml (1.0.4)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bump
-  fakeweb
   minitest (~> 4.0)
   minitest-rg
   mocha (~> 0.13)
   rake
+  webmock
 
 BUNDLED WITH
    1.11.2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,7 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/rg'
 require 'minitest/spec'
-require 'fakeweb'
+require 'webmock/minitest'
 require 'mocha/setup'
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-
-FakeWeb.allow_net_connect = false

--- a/test/unit/agreement_test.rb
+++ b/test/unit/agreement_test.rb
@@ -87,8 +87,7 @@ class TicketSharing::AgreementTest < MiniTest::Unit::TestCase
     }
 
     agreement = TicketSharing::Agreement.new(attributes)
-    FakeWeb.register_uri(:post,
-      'http://example.com/sharing/agreements/5ad614f4', :body => '')
+    stub_request(:post, 'http://example.com/sharing/agreements/5ad614f4')
 
     assert agreement.send_to(attributes['receiver_url'])
   end
@@ -100,9 +99,8 @@ class TicketSharing::AgreementTest < MiniTest::Unit::TestCase
     }
 
     agreement = TicketSharing::Agreement.new(attributes)
-    FakeWeb.register_uri(:post,
-      'http://example.com/sharing/agreements/5ad614f4',
-      :body => '', :status => [400, "Bad Request"])
+    stub_request(:post, 'http://example.com/sharing/agreements/5ad614f4')
+      .to_return(:status => 400)
 
     assert_raises(TicketSharing::Error) do
       agreement.send_to(attributes['receiver_url'])
@@ -110,9 +108,8 @@ class TicketSharing::AgreementTest < MiniTest::Unit::TestCase
   end
 
   def test_should_update_partner
-    FakeWeb.last_request = nil
-    FakeWeb.register_uri(:put,
-      'http://example.com/sharing/agreements/5ad614f4', :body => '')
+    stub_request(:put, 'http://example.com/sharing/agreements/5ad614f4')
+      .with(:body => /5ad614f4/, :headers => { 'X-Ticket-Sharing-Token' => '5ad614f4:APIKEY123' })
 
     attributes = {
       'receiver_url' => 'http://example.com/sharing',
@@ -122,11 +119,6 @@ class TicketSharing::AgreementTest < MiniTest::Unit::TestCase
 
     agreement = TicketSharing::Agreement.new(attributes)
     assert agreement.update_partner(attributes['receiver_url'])
-
-    request = FakeWeb.last_request
-    assert_equal('/sharing/agreements/5ad614f4', request.path)
-    assert_match(/5ad614f4/, request.body)
-    assert_equal('5ad614f4:APIKEY123', request['X-Ticket-Sharing-Token'])
   end
 
   def test_should_deserialize_current_actor


### PR DESCRIPTION
:octopus::computer:

/cc @grosser 

### Description
FakeWeb doesn't seem maintained anymore. There's a lot of deprecation warnings when running tests with it.

### Steps to merge
* [ ] :+1: from the team

### Risks
* None (test only)