### PR TITLE
feat: add custom status to ticket model

### DIFF
--- a/lib/ticket_sharing/ticket.rb
+++ b/lib/ticket_sharing/ticket.rb
@@ -9,7 +9,7 @@ module TicketSharing
   class Ticket < Base
 
     fields :uuid, :subject, :requested_at, :status, :requester, :comments,
-      :current_actor, :tags, :original_id, :custom_fields
+      :current_actor, :tags, :original_id, :custom_fields, :custom_status
 
     attr_accessor :agreement
     attr_reader :response

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -131,6 +131,13 @@ describe TicketSharing::Ticket do
     expect(ticket.comments[1].author.name).to eq('Actor One')
   end
 
+  it 'serializes the custom status' do
+    ticket = described_class.new('custom_status' => "custom_status_str")
+    json = ticket.to_json
+    parsed_ticket = described_class.parse(json)
+    expect(parsed_ticket.custom_status).to eq "custom_status_str"
+  end
+
   it 'serializes the custom fields' do
     custom_fields = {
       'foo' => 'bar',


### PR DESCRIPTION
Adds a custom status attribute to the shared ticket class so it can be communicated across accounts.