### PR TITLE
fix(client): update response handling for HTTP 400 Bad Request status

### DIFF
--- a/lib/ticket_sharing/client.rb
+++ b/lib/ticket_sharing/client.rb
@@ -41,7 +41,7 @@ module TicketSharing
       @success = case response.status
       when (200..299)
         true
-      when 401, 403, 404, 405, 408, 410, 422, 500..599
+      when 400, 401, 403, 404, 405, 408, 410, 422, 500..599
         false
       else
         raise TicketSharing::Error.new(%Q{#{response.status}\n\n#{response.body}})

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -102,9 +102,7 @@ describe TicketSharing::Agreement do
     stub_request(:post, 'http://example.com/sharing/agreements/5ad614f4')
       .to_return(status: 400)
 
-    expect {
-      agreement.send_to(attributes['receiver_url'])
-    }.to raise_error(TicketSharing::Error)
+    expect(agreement.send_to(attributes['receiver_url'])).to be(400)
   end
 
   it 'updates partner' do

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -77,9 +77,8 @@ describe TicketSharing::Client do
     stub_request(:post, @base_url + @path)
       .and_return(body: the_body, status: 400)
 
-    expect {
-      client, response = do_request(:post)
-    }.to raise_error(TicketSharing::Error, %Q{400\n\n} + the_body)
+    client, response = do_request(:post)
+    expect(response.status).to be(400)
   end
 
   it 'handles a failing post with 403 response' do


### PR DESCRIPTION
This PR adds HTTP response code 400 as a "valid" error response. As a result, 400s will no longer raise an exception and will fail in the same way that existing 4xx and 5xx codes that are already allow listed.

BREAKING CHANGE:
- If any functionality previously relied on 400 responses being treated as successful, those cases may now break, as they will be recognized as failures instead. This change should be carefully reviewed in the context of dependent components or services that may rely on the old behavior.