### PR TITLE
chore: bump faraday to >= 2.14.0 to patch security vulnerability

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.2', '3.3', '3.4', '3.5', '4.0']
 
     steps:
     - name: Checkout source code

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    ticket_sharing (2.1.4)
-      faraday (~> 2.0.0)
+    ticket_sharing (2.2.0)
+      faraday (>= 2.14.1)
 
 GEM
   remote: https://rubygems.org/
@@ -13,33 +13,39 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    diff-lcs (1.2.5)
-    faraday (2.0.1)
-      faraday-net_http (~> 2.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (2.1.0)
+    diff-lcs (1.6.2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     hashdiff (1.2.1)
-    public_suffix (3.1.1)
+    json (2.19.3)
+    logger (1.7.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    public_suffix (7.0.5)
     rake (12.3.3)
     rexml (3.4.4)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
-    ruby2_keywords (0.0.5)
-    webmock (3.0.1)
-      addressable (>= 2.3.6)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    uri (1.1.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -47,9 +53,9 @@ PLATFORMS
 DEPENDENCIES
   rake
   rexml (>= 3.4.2)
-  rspec
+  rspec (>= 3.12)
   ticket_sharing!
-  webmock (~> 3.0.0)
+  webmock (>= 3.18.0)
 
 BUNDLED WITH
    2.3.11

--- a/lib/ticket_sharing/version.rb
+++ b/lib/ticket_sharing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TicketSharing
-  VERSION = "2.1.4"
+  VERSION = "2.2.0"
 end

--- a/ticket_sharing.gemspec
+++ b/ticket_sharing.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new 'ticket_sharing' do |s|
   s.homepage = 'https://github.com/zendesk/ticket_sharing'
   s.license = 'Apache License Version 2.0'
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 3.2.0'
 
-  s.add_dependency 'faraday', '~> 2.0.0'
+  s.add_dependency 'faraday', '>= 2.14.1'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'webmock', '~> 3.0.0'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock', '>= 3.18.0'
+  s.add_development_dependency 'rspec', '>= 3.12'
   s.add_development_dependency 'rexml', '>= 3.4.2'
 end


### PR DESCRIPTION
To address:
- https://github.com/zendesk/ticket_sharing/security/dependabot/15
- https://github.com/zendesk/ticket_sharing/security/dependabot/16


Notes:
- needed to bump ruby to >=3.2 to satisfy public_suffix 7.0.x in order to bump Web Mock, which an older version was failing in ruby 3.4. 