### PR TITLE
chore: update User-Agent header in ticket sharing requests

### DIFF
--- a/lib/ticket_sharing/request.rb
+++ b/lib/ticket_sharing/request.rb
@@ -4,6 +4,7 @@ require 'ticket_sharing/error'
 module TicketSharing
   class Request
     MAX_REDIRECTS = 2
+    USER_AGENT = 'Zendesk-TicketSharing'
 
     CA_PATH = "/etc/ssl/certs"
 
@@ -50,7 +51,8 @@ module TicketSharing
       request.url url
       {
         'Accept'       => 'application/json',
-        'Content-Type' => 'application/json'
+        'Content-Type' => 'application/json',
+        'User-Agent'   => USER_AGENT
       }.merge(options[:headers] || {}).each do |h, v|
         request.headers[h] = v
       end


### PR DESCRIPTION
## Summary
- Set a custom `User-Agent: Zendesk-TicketSharing` header on all outbound ticket sharing requests
- Addresses pentest finding that the default `Faraday v{version}` User-Agent discloses internal dependency versions to partners

## Details
The fix is in `Request#configure_request`, which is the single point for all outbound HTTP requests. This ensures the header is set regardless of which Faraday connection is injected (e.g. Kragle in `zendesk/zendesk`).

## Test plan
Testing details: https://zendesk.atlassian.net/browse/BOX-5577?focusedCommentId=2371246
- [x] Local repro confirms `Zendesk-TicketSharing` is sent with the change
- [x] Local repro confirms `Faraday v{version}` is sent without the change
- [x] Existing specs pass (`bundle exec rspec`)